### PR TITLE
Specify version for anndataR installation

### DIFF
--- a/envs/environment_setup.sh
+++ b/envs/environment_setup.sh
@@ -7,6 +7,6 @@ CONDA_BASE=$(conda info --base)
 source ${CONDA_BASE}/etc/profile.d/conda.sh
 conda activate snakemake_binomial_regression
 
-R -e "library(devtools); devtools::install_github('scverse/anndataR')"
+R -e "library(devtools); devtools::install_github('scverse/anndataR@v0.2.0')"
 R -e "library(devtools); devtools::install_version('car', version = '3.1-3', repos = 'http://cran.us.r-project.org')"
 R -e "install.packages('metRology', repos='http://cran.us.r-project.org')"


### PR DESCRIPTION
From >=0.2.0 onwards, anndataR requires rhdf5 instead of hdf5r to read/write H5AD files, and thus requires R4.5

Many of the package versions no longer work as intended with R4.5 or rhdf5.

Thus enforcing anndataR v0.2.0 to keep everything else stable.